### PR TITLE
Use actual server port in redirect_uri to allow automatic assignment

### DIFF
--- a/google_auth_oauthlib/flow.py
+++ b/google_auth_oauthlib/flow.py
@@ -402,7 +402,8 @@ class InstalledAppFlow(Flow):
         local_server = wsgiref.simple_server.make_server(
             host, port, wsgi_app, handler_class=_WSGIRequestHandler)
 
-        self.redirect_uri = 'http://{}:{}/'.format(host, local_server.server_port)
+        self.redirect_uri = 'http://{}:{}/'.format(
+            host, local_server.server_port)
         auth_url, _ = self.authorization_url(**kwargs)
 
         if open_browser:

--- a/google_auth_oauthlib/flow.py
+++ b/google_auth_oauthlib/flow.py
@@ -398,13 +398,12 @@ class InstalledAppFlow(Flow):
             google.oauth2.credentials.Credentials: The OAuth 2.0 credentials
                 for the user.
         """
-        self.redirect_uri = 'http://{}:{}/'.format(host, port)
-
-        auth_url, _ = self.authorization_url(**kwargs)
-
         wsgi_app = _RedirectWSGIApp(success_message)
         local_server = wsgiref.simple_server.make_server(
             host, port, wsgi_app, handler_class=_WSGIRequestHandler)
+
+        self.redirect_uri = 'http://{}:{}/'.format(host, local_server.server_port)
+        auth_url, _ = self.authorization_url(**kwargs)
 
         if open_browser:
             webbrowser.open(auth_url, new=1, autoraise=True)


### PR DESCRIPTION
Allows port 0 for localhost flows, which assigns an random unused ephemeral port. Intended as proper fix for gsuitedevs/python-samples#89

