### PR TITLE
Add `get_user_credentials` function to get your user credentials.

### DIFF
--- a/google_auth_oauthlib/__init__.py
+++ b/google_auth_oauthlib/__init__.py
@@ -12,6 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""oauthlib integration for Google Auth
+
+This library provides `oauthlib <https://oauthlib.readthedocs.io/>`__
+integration with `google-auth <https://google-auth.readthedocs.io/>`__.
+"""
+
 from .interactive import get_user_credentials
 
 __all__ = ["get_user_credentials"]

--- a/google_auth_oauthlib/__init__.py
+++ b/google_auth_oauthlib/__init__.py
@@ -1,0 +1,17 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .interactive import get_user_credentials
+
+__all__ = ["get_user_credentials"]

--- a/google_auth_oauthlib/interactive.py
+++ b/google_auth_oauthlib/interactive.py
@@ -24,6 +24,13 @@ from __future__ import absolute_import
 import google_auth_oauthlib.flow
 
 
+# This client information belongs to the client authentication team and is
+# already bundled as part of the Google Cloud SDK, as used by the command:
+#
+#     gcloud auth application-default login
+#
+# By bundling these identifiers here, we avoid an unnecessary dependency on
+# having the gcloud command-line tool installed.
 _CLIENT_ID = "764086051850-6qr4p6gpi6hn506pt8ejuq83di341hur.apps.googleusercontent.com"
 _CLIENT_SECRET = "d-FL95Q19q7MQmFpd7hHD0Ty"
 

--- a/google_auth_oauthlib/interactive.py
+++ b/google_auth_oauthlib/interactive.py
@@ -1,0 +1,72 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Get user credentials from interactive code environments.
+
+This module contains helpers for getting user credentials from interactive
+code environments installed on a development machine, such as Jupyter
+notebooks.
+"""
+
+from __future__ import absolute_import
+
+import google_auth_oauthlib.flow
+
+
+_CLIENT_ID = "764086051850-6qr4p6gpi6hn506pt8ejuq83di341hur.apps.googleusercontent.com"
+_CLIENT_SECRET = "d-FL95Q19q7MQmFpd7hHD0Ty"
+
+
+def get_user_credentials(scopes):
+    """Gets credentials associated with your Google user account.
+
+    This function authenticates using your user credentials by going through
+    the OAuth 2.0 flow. You'll open a browser window asking for you to
+    authenticate to your Google account using authentication library. The
+    permissions it requests correspond to the scopes you've provided.
+
+    .. warning::
+        If you are writing an application, tool, or library which accesses
+        Google APIs, use the :mod:`google_auth_oauthlib.flow` module directly
+        and supply client information identifying your application. You are
+        `required by the Google APIs terms of service
+        <https://developers.google.com/terms/#c_permitted_access>`__ to
+        accurately identify your application.
+
+    Args:
+        scopes (Sequence[str]):
+            A list of scopes to use when authenticating to Google APIs. See
+            the `list of OAuth 2.0 scopes for Google APIs
+            <https://developers.google.com/identity/protocols/googlescopes>`_.
+
+    Returns:
+        google.oauth2.credentials.Credentials:
+            The OAuth 2.0 credentials for the user.
+    """
+
+    client_config = {
+        "installed": {
+            "client_id": _CLIENT_ID,
+            "client_secret": _CLIENT_SECRET,
+            "redirect_uris": ["urn:ietf:wg:oauth:2.0:oob"],
+            "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+            "token_uri": "https://accounts.google.com/o/oauth2/token",
+        }
+    }
+
+    app_flow = google_auth_oauthlib.flow.InstalledAppFlow.from_client_config(
+        client_config, scopes=scopes
+    )
+
+    return app_flow.run_console()

--- a/google_auth_oauthlib/interactive.py
+++ b/google_auth_oauthlib/interactive.py
@@ -24,41 +24,35 @@ from __future__ import absolute_import
 import google_auth_oauthlib.flow
 
 
-# This client information belongs to the client authentication team and is
-# already bundled as part of the Google Cloud SDK, as used by the command:
-#
-#     gcloud auth application-default login
-#
-# By bundling these identifiers here, we avoid an unnecessary dependency on
-# having the gcloud command-line tool installed.
-_CLIENT_ID = (
-    "764086051850-6qr4p6gpi6hn506pt8ejuq83di341hur"
-    ".apps.googleusercontent.com"
-)
-_CLIENT_SECRET = "d-FL95Q19q7MQmFpd7hHD0Ty"
-
-
-def get_user_credentials(scopes):
+def get_user_credentials(scopes, client_id, client_secret):
     """Gets credentials associated with your Google user account.
 
     This function authenticates using your user credentials by going through
-    the OAuth 2.0 flow. You'll open a browser window asking for you to
-    authenticate to your Google account using authentication library. The
-    permissions it requests correspond to the scopes you've provided.
+    the OAuth 2.0 flow. You'll open a browser window to authenticate to your
+    Google account. The permissions it requests correspond to the scopes
+    you've provided.
 
-    .. warning::
-        If you are writing an application, tool, or library which accesses
-        Google APIs, use the :mod:`google_auth_oauthlib.flow` module directly
-        and supply client information identifying your application. You are
-        `required by the Google APIs terms of service
-        <https://developers.google.com/terms/#c_permitted_access>`__ to
-        accurately identify your application.
+    To obtain the ``client_id`` and ``client_secret``, create an **OAuth
+    client ID** with application type **Other** from the `Credentials page on
+    the Google Developer's Console
+    <https://console.developers.google.com/apis/credentials>`_. Learn more
+    with the `Authenticating as an end user
+    <https://cloud.google.com/docs/authentication/end-user>`_ guide.
 
     Args:
         scopes (Sequence[str]):
             A list of scopes to use when authenticating to Google APIs. See
             the `list of OAuth 2.0 scopes for Google APIs
             <https://developers.google.com/identity/protocols/googlescopes>`_.
+        client_id (str):
+            A string that identifies your application to Google APIs. Find
+            this value in the `Credentials page on the Google Developer's
+            Console
+            <https://console.developers.google.com/apis/credentials>`_.
+        client_secret (str):
+            A string that verifies your application to Google APIs. Find this
+            value in the `Credentials page on the Google Developer's Console
+            <https://console.developers.google.com/apis/credentials>`_.
 
     Returns:
         google.oauth2.credentials.Credentials:
@@ -67,11 +61,11 @@ def get_user_credentials(scopes):
 
     client_config = {
         "installed": {
-            "client_id": _CLIENT_ID,
-            "client_secret": _CLIENT_SECRET,
+            "client_id": client_id,
+            "client_secret": client_secret,
             "redirect_uris": ["urn:ietf:wg:oauth:2.0:oob"],
             "auth_uri": "https://accounts.google.com/o/oauth2/auth",
-            "token_uri": "https://accounts.google.com/o/oauth2/token",
+            "token_uri": "https://oauth2.googleapis.com/token",
         }
     }
 

--- a/google_auth_oauthlib/interactive.py
+++ b/google_auth_oauthlib/interactive.py
@@ -57,6 +57,35 @@ def get_user_credentials(scopes, client_id, client_secret):
     Returns:
         google.oauth2.credentials.Credentials:
             The OAuth 2.0 credentials for the user.
+
+    Examples:
+        Get credentials for your user account and use them to run a query
+        with BigQuery::
+
+            import google_auth_oauthlib
+
+            # TODO: Create a client ID for your project.
+            client_id = "YOUR-CLIENT-ID.apps.googleusercontent.com"
+            client_secret = "abc_ThIsIsAsEcReT"
+
+            # TODO: Choose the needed scopes for your applications.
+            scopes = ["https://www.googleapis.com/auth/cloud-platform"]
+
+            credentials = google_auth_oauthlib.get_user_credentials(
+                scopes, client_id, client_secret
+            )
+
+            # 1. Open the link.
+            # 2. Authorize the application to have access to your account.
+            # 3. Copy and paste the authorization code to the prompt.
+
+            # Use the credentials to construct a client for Google APIs.
+            from google.cloud import bigquery
+
+            bigquery_client = bigquery.Client(
+                credentials=credentials, project="your-project-id"
+            )
+            print(list(bigquery_client.query("SELECT 1").result()))
     """
 
     client_config = {

--- a/google_auth_oauthlib/interactive.py
+++ b/google_auth_oauthlib/interactive.py
@@ -31,7 +31,10 @@ import google_auth_oauthlib.flow
 #
 # By bundling these identifiers here, we avoid an unnecessary dependency on
 # having the gcloud command-line tool installed.
-_CLIENT_ID = "764086051850-6qr4p6gpi6hn506pt8ejuq83di341hur.apps.googleusercontent.com"
+_CLIENT_ID = (
+    "764086051850-6qr4p6gpi6hn506pt8ejuq83di341hur"
+    ".apps.googleusercontent.com"
+)
 _CLIENT_SECRET = "d-FL95Q19q7MQmFpd7hHD0Ty"
 
 

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -19,7 +19,10 @@ def test_get_user_credentials():
     from google_auth_oauthlib import flow
     from google_auth_oauthlib import interactive as module_under_test
 
-    mock_flow_instance = mock.create_autospec(flow.InstalledAppFlow, instance=True)
+    mock_flow_instance = mock.create_autospec(
+        flow.InstalledAppFlow,
+        instance=True
+    )
 
     with mock.patch(
         "google_auth_oauthlib.flow.InstalledAppFlow", autospec=True
@@ -27,5 +30,8 @@ def test_get_user_credentials():
         mock_flow.from_client_config.return_value = mock_flow_instance
         module_under_test.get_user_credentials(["scopes"])
 
-    mock_flow.from_client_config.assert_called_once_with(mock.ANY, scopes=["scopes"])
+    mock_flow.from_client_config.assert_called_once_with(
+        mock.ANY,
+        scopes=["scopes"],
+    )
     mock_flow_instance.run_console.assert_called_once()

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -28,10 +28,13 @@ def test_get_user_credentials():
         "google_auth_oauthlib.flow.InstalledAppFlow", autospec=True
     ) as mock_flow:
         mock_flow.from_client_config.return_value = mock_flow_instance
-        module_under_test.get_user_credentials(["scopes"])
+        module_under_test.get_user_credentials(["scopes"], "some-client-id", "shh-secret")
 
     mock_flow.from_client_config.assert_called_once_with(
         mock.ANY,
         scopes=["scopes"],
     )
+    actual_client_config = mock_flow.from_client_config.call_args[0][0]
+    assert actual_client_config["installed"]["client_id"] == "some-client-id"
+    assert actual_client_config["installed"]["client_secret"] == "shh-secret"
     mock_flow_instance.run_console.assert_called_once()

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -25,7 +25,7 @@ def test_get_user_credentials():
     )
 
     with mock.patch(
-        "google_auth_oauthlib.flow.InstalledAppFlow", autospec=True
+            "google_auth_oauthlib.flow.InstalledAppFlow", autospec=True
     ) as mock_flow:
         mock_flow.from_client_config.return_value = mock_flow_instance
         module_under_test.get_user_credentials(

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -1,0 +1,31 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import mock
+
+
+def test_get_user_credentials():
+    from google_auth_oauthlib import flow
+    from google_auth_oauthlib import interactive as module_under_test
+
+    mock_flow_instance = mock.create_autospec(flow.InstalledAppFlow, instance=True)
+
+    with mock.patch(
+        "google_auth_oauthlib.flow.InstalledAppFlow", autospec=True
+    ) as mock_flow:
+        mock_flow.from_client_config.return_value = mock_flow_instance
+        module_under_test.get_user_credentials(["scopes"])
+
+    mock_flow.from_client_config.assert_called_once_with(mock.ANY, scopes=["scopes"])
+    mock_flow_instance.run_console.assert_called_once()

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -28,7 +28,11 @@ def test_get_user_credentials():
         "google_auth_oauthlib.flow.InstalledAppFlow", autospec=True
     ) as mock_flow:
         mock_flow.from_client_config.return_value = mock_flow_instance
-        module_under_test.get_user_credentials(["scopes"], "some-client-id", "shh-secret")
+        module_under_test.get_user_credentials(
+            ["scopes"],
+            "some-client-id",
+            "shh-secret",
+        )
 
     mock_flow.from_client_config.assert_called_once_with(
         mock.ANY,


### PR DESCRIPTION
This function is intended to be used in interactive code examples, such
as from a Jupyter notebook or when developing scripts locally. It uses
the same client ID as the `gcloud auth authentication-default login`
command-line tool, so should work for most Google APIs.

Tested manually with the BigQuery API:

```python
import os

import google_auth_oauthlib
from google.cloud import bigquery

credentials = google_auth_oauthlib.get_user_credentials(
    ["https://www.googleapis.com/auth/cloud-platform"]
)

client = bigquery.Client(
    credentials=credentials,
    project=os.environ["PROJECT_ID"],
)
df = client.query(
    """
    SELECT
      CONCAT(
        'https://stackoverflow.com/questions/',
        CAST(id as STRING)) as url,
      view_count
    FROM `bigquery-public-data.stackoverflow.posts_questions`
    WHERE tags like '%google-bigquery%'
    ORDER BY view_count DESC
    LIMIT 10
    """
).to_dataframe()
print(df)
```

Closes #39 