### PR TITLE
Add .kokoro, drop 3.4 and pypy from test runs.

### DIFF
--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -21,6 +21,8 @@ cd github/google-auth-library-python-oauthlib
 # Disable buffering, so that the logs stream through.
 export PYTHONUNBUFFERED=1
 
+python3 -m pip install nox
+
 # Run tests
 nox -s lint test
 

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail
+
+cd github/google-auth-library-python-oauthlib
+
+# Disable buffering, so that the logs stream through.
+export PYTHONUNBUFFERED=1
+
+# Run tests
+nox -s lint test
+
+# remove all files, preventing kokoro from trying to sync them.
+rm -rf *

--- a/.kokoro/common.cfg
+++ b/.kokoro/common.cfg
@@ -1,0 +1,19 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Download trampoline resources.
+gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
+
+# Use the trampoline script to run in docker.
+build_file: "google-auth-library-python-oauthlib/.kokoro/trampoline.sh"
+
+# Configure the docker image for kokoro-trampoline.
+env_vars: {
+    key: "TRAMPOLINE_IMAGE"
+    value: "gcr.io/cloud-devrel-kokoro-resources/python-multi"
+}
+
+# Tell the trampoline which build file to use.
+env_vars: {
+    key: "TRAMPOLINE_BUILD_FILE"
+    value: "github/google-auth-library-python-oauthlib/.kokoro/build.sh"
+}

--- a/.kokoro/continuous.cfg
+++ b/.kokoro/continuous.cfg
@@ -1,0 +1,1 @@
+# Format: //devtools/kokoro/config/proto/build.proto

--- a/.kokoro/presubmit.cfg
+++ b/.kokoro/presubmit.cfg
@@ -1,0 +1,1 @@
+# Format: //devtools/kokoro/config/proto/build.proto

--- a/.kokoro/release.cfg
+++ b/.kokoro/release.cfg
@@ -1,0 +1,32 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Download secrets from Cloud Storage.
+gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/yoshi-tools"
+
+# The github token is stored here.
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73713
+      keyname: "releasetool-magictoken"
+      # TODO(busunkim): remove this after secrets have globally propagated
+      backend_type: FASTCONFIGPUSH
+    }
+  }
+}
+
+# The github token is stored here.
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73713
+      keyname: "magic-github-proxy-api-key"
+      # TODO(busunkim): remove this after secrets have globally propagated
+      backend_type: FASTCONFIGPUSH
+    }
+  }
+}
+
+env_vars: {
+    key: "TRAMPOLINE_BUILD_FILE"
+    value: "github/google-auth-library-python-oauthlib/.kokoro/release.sh"
+}

--- a/.kokoro/release.sh
+++ b/.kokoro/release.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail
+
+# Enable the publish build reporter
+python3 -m pip install gcp-releasetool
+python3 -m releasetool publish-reporter-script > /tmp/publisher-script; source /tmp/publisher-script
+
+
+cd github/releasetool
+TWINE_USERNAME=$(cat "${KOKORO_GFILE_DIR}/twine-username.txt")
+TWINE_PASSWORD=$(cat "${KOKORO_GFILE_DIR}/twine-password.txt")
+
+# Disable buffering, so that the logs stream through.
+export PYTHONUNBUFFERED=1
+
+python3 -m pip install --upgrade --quiet setuptools wheel twine
+
+python3 setup.py sdist bdist_wheel
+twine upload --username "${TWINE_USERNAME}" --password "${TWINE_PASSWORD}" dist/*

--- a/.kokoro/release.sh
+++ b/.kokoro/release.sh
@@ -21,7 +21,7 @@ python3 -m pip install gcp-releasetool
 python3 -m releasetool publish-reporter-script > /tmp/publisher-script; source /tmp/publisher-script
 
 
-cd github/releasetool
+cd github/google-auth-library-python-oauthlib
 TWINE_USERNAME=$(cat "${KOKORO_GFILE_DIR}/twine-username.txt")
 TWINE_PASSWORD=$(cat "${KOKORO_GFILE_DIR}/twine-password.txt")
 

--- a/.kokoro/trampoline.sh
+++ b/.kokoro/trampoline.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -eo pipefail
+# Always run the cleanup script, regardless of the success of bouncing into
+# the container.
+function cleanup() {
+    chmod +x ${KOKORO_GFILE_DIR}/trampoline_cleanup.sh
+    ${KOKORO_GFILE_DIR}/trampoline_cleanup.sh
+    echo "cleanup";
+}
+trap cleanup EXIT
+python3 "${KOKORO_GFILE_DIR}/trampoline_v1.py"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,10 @@ matrix:
     env: TOXENV=lint
   - python: 2.7
     env: TOXENV=py27
-  - python: 3.4
-    env: TOXENV=py34
   - python: 3.5
     env: TOXENV=py35
   - python: 3.6
     env: TOXENV=py36
-  - python: pypy
-    env: TOXENV=pypy
   - python: 3.6
     env: TOXENV=cover
 cache:

--- a/noxfile.py
+++ b/noxfile.py
@@ -66,7 +66,7 @@ def lint(session):
     )
 
 
-@nox.session(python=["2.7", "3.5", "3.6", "3.7", "pypy"])
+@nox.session(python=["2.7", "3.5", "3.6", "3.7"])
 def test(session):
     session.install("mock", "pytest", "pytest-cov", "futures", "click")
     session.install(".")


### PR DESCRIPTION
Will remove Travis after Kokoro setup is complete.

---

(pypy needs to be installed in python-multi so it is available in Kokoro. OR the pypy session can be removed.)