### PR TITLE
Fix comma splice in default success message

### DIFF
--- a/google_auth_oauthlib/flow.py
+++ b/google_auth_oauthlib/flow.py
@@ -365,7 +365,7 @@ class InstalledAppFlow(Flow):
     authorization code. Used only by the console strategy."""
 
     _DEFAULT_WEB_SUCCESS_MESSAGE = (
-        'The authentication flow has completed, you may close this window.')
+        'The authentication flow has completed. You may close this window.')
 
     def run_console(
             self,


### PR DESCRIPTION
Test Plan:
Running `git grep ', you may'` shows no more occurrences of this string.

wchargin-branch: success-comma-splice