### PR TITLE
Pin a major & minor version of google-auth

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ from setuptools import setup
 
 TOOL_DEPENDENCIES = "click"
 
-DEPENDENCIES = ("google-auth", "requests-oauthlib>=0.7.0")
+DEPENDENCIES = ("google-auth>=1.11,<1.12", "requests-oauthlib>=0.7.0")
 
 
 with io.open("README.rst", "r") as fh:


### PR DESCRIPTION
There was a bug (or breaking change? unclear) released in `google-auth` 1.11.1 (a patch version). This bug affected us via our dependency on `google-auth-oauthlib`. Unfortunately, to avoid this bug entirely, `google-auth-oauthlib` would need to pin a patch version, which seems unreasonable. However, I was surprised to find that `google-auth-oauthlib` doesn't pin a major and minor version of `google-auth`. This PR pins `google-auth-oauthlib` to `1.11.x`.