### PR TITLE
Protocol should be changed in a correct way.

### DIFF
--- a/google_auth_oauthlib/flow.py
+++ b/google_auth_oauthlib/flow.py
@@ -465,7 +465,7 @@ class InstalledAppFlow(Flow):
 
         # Note: using https here because oauthlib is very picky that
         # OAuth 2.0 should only occur over https.
-        authorization_response = wsgi_app.last_request_uri.replace("http", "https")
+        authorization_response = wsgi_app.last_request_uri.replace("http:", "https:")
         self.fetch_token(authorization_response=authorization_response)
 
         return self.credentials


### PR DESCRIPTION
The way we change the protocol is problematic. For example, the last_request_uri can have scopes which contain "https", i.e. https://www.googleapis.com/auth/cloud-platform. After the replacement, it becomes httpss://www.googleapis.com/auth/cloud-platform