### PR TITLE
redirect url with "/" at the end of URL doesn't match

### DIFF
--- a/google_auth_oauthlib/flow.py
+++ b/google_auth_oauthlib/flow.py
@@ -453,7 +453,7 @@ class InstalledAppFlow(Flow):
             host, port, wsgi_app, handler_class=_WSGIRequestHandler
         )
 
-        self.redirect_uri = "http://{}:{}/".format(host, local_server.server_port)
+        self.redirect_uri = "http://{}:{}".format(host, local_server.server_port)
         auth_url, _ = self.authorization_url(**kwargs)
 
         if open_browser:


### PR DESCRIPTION
Fixed URL name for alowed urls. 
For example message: "The redirect URI in the request, http://localhost:8080/, does not match the ones authorized for the OAuth client."