### PR TITLE
Fix redirect_uris mismatch due to trailing slash.

### DIFF
--- a/google_auth_oauthlib/flow.py
+++ b/google_auth_oauthlib/flow.py
@@ -453,7 +453,7 @@ class InstalledAppFlow(Flow):
             host, port, wsgi_app, handler_class=_WSGIRequestHandler
         )
 
-        self.redirect_uri = "http://{}:{}/".format(host, local_server.server_port)
+        self.redirect_uri = "http://{}:{}".format(host, local_server.server_port)
         auth_url, _ = self.authorization_url(**kwargs)
 
         if open_browser:


### PR DESCRIPTION
Removing the leading slash that is added to redirect_uris. For issue #80 
Could be fixed server side of oauth by accepting redirect_uris with the extra slash.