### PR TITLE
docs: fix link to client secrets format doc

### DIFF
--- a/google_auth_oauthlib/flow.py
+++ b/google_auth_oauthlib/flow.py
@@ -152,8 +152,7 @@ class Flow(object):
                 format.
 
         .. _client secrets:
-            https://developers.google.com/api-client-library/python/guide
-            /aaa_client_secrets
+            https://github.com/googleapis/google-api-python-client/blob/master/docs/client-secrets.md
         """
         if "web" in client_config:
             client_type = "web"

--- a/google_auth_oauthlib/flow.py
+++ b/google_auth_oauthlib/flow.py
@@ -119,8 +119,7 @@ class Flow(object):
             autogenerate_code_verifier (bool): If true, auto-generate a
                 code_verifier.
         .. _client secrets:
-            https://developers.google.com/api-client-library/python/guide
-            /aaa_client_secrets
+            https://github.com/googleapis/google-api-python-client/blob/master/docs/client-secrets.md
         """
         self.client_type = client_type
         """str: The client type, either ``'web'`` or ``'installed'``"""

--- a/google_auth_oauthlib/helpers.py
+++ b/google_auth_oauthlib/helpers.py
@@ -51,8 +51,7 @@ def session_from_client_config(client_config, scopes, **kwargs):
             oauthlib session and the validated client configuration.
 
     .. _client secrets:
-        https://developers.google.com/api-client-library/python/guide
-        /aaa_client_secrets
+        https://github.com/googleapis/google-api-python-client/blob/master/docs/client-secrets.md
     """
 
     if "web" in client_config:
@@ -89,8 +88,7 @@ def session_from_client_secrets_file(client_secrets_file, scopes, **kwargs):
             oauthlib session and the validated client configuration.
 
     .. _client secrets:
-        https://developers.google.com/api-client-library/python/guide
-        /aaa_client_secrets
+        https://github.com/googleapis/google-api-python-client/blob/master/docs/client-secrets.md
     """
     with open(client_secrets_file, "r") as json_file:
         client_config = json.load(json_file)


### PR DESCRIPTION
It seems documentation for the "client secrets" file has moved here: https://github.com/googleapis/google-api-python-client/blob/master/docs/client-secrets.md