### PR TITLE
fix: add redirect_uri_trailing slash param to run_local_server

### DIFF
--- a/google_auth_oauthlib/flow.py
+++ b/google_auth_oauthlib/flow.py
@@ -422,6 +422,7 @@ class InstalledAppFlow(Flow):
         authorization_prompt_message=_DEFAULT_AUTH_PROMPT_MESSAGE,
         success_message=_DEFAULT_WEB_SUCCESS_MESSAGE,
         open_browser=True,
+        redirect_uri_trailing_slash=True,
         **kwargs
     ):
         """Run the flow using the server strategy.
@@ -444,6 +445,8 @@ class InstalledAppFlow(Flow):
                 the authorization flow is complete.
             open_browser (bool): Whether or not to open the authorization URL
                 in the user's browser.
+            redirect_uri_trailing_slash (bool): whether or not to add trailing
+                slash when constructing the redirect_uri. Default value is True.
             kwargs: Additional keyword arguments passed through to
                 :meth:`authorization_url`.
 
@@ -458,7 +461,10 @@ class InstalledAppFlow(Flow):
             host, port, wsgi_app, handler_class=_WSGIRequestHandler
         )
 
-        self.redirect_uri = "http://{}:{}/".format(host, local_server.server_port)
+        redirect_uri_format = (
+            "http://{}:{}/" if redirect_uri_trailing_slash else "http://{}:{}"
+        )
+        self.redirect_uri = redirect_uri_format.format(host, local_server.server_port)
         auth_url, _ = self.authorization_url(**kwargs)
 
         if open_browser:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    webtest: mark a test as a webtest.

--- a/tests/unit/test_flow.py
+++ b/tests/unit/test_flow.py
@@ -321,6 +321,7 @@ class TestInstalledAppFlow(object):
         assert credentials._refresh_token == mock.sentinel.refresh_token
         assert credentials.id_token == mock.sentinel.id_token
         assert webbrowser_mock.open.called
+        assert instance.redirect_uri == f"http://localhost:{port}/"
 
         expected_auth_response = auth_redirect_url.replace("http", "https")
         mock_fetch_token.assert_called_with(
@@ -341,7 +342,13 @@ class TestInstalledAppFlow(object):
         instance.code_verifier = "amanaplanacanalpanama"
 
         with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-            future = pool.submit(partial(instance.run_local_server, port=port))
+            future = pool.submit(
+                partial(
+                    instance.run_local_server,
+                    port=port,
+                    redirect_uri_trailing_slash=False,
+                )
+            )
 
             while not future.done():
                 try:
@@ -355,6 +362,7 @@ class TestInstalledAppFlow(object):
         assert credentials._refresh_token == mock.sentinel.refresh_token
         assert credentials.id_token == mock.sentinel.id_token
         assert webbrowser_mock.open.called
+        assert instance.redirect_uri == f"http://localhost:{port}"
 
         expected_auth_response = auth_redirect_url.replace("http", "https")
         mock_fetch_token.assert_called_with(


### PR DESCRIPTION
Fixes #110 

Add a new `redirect_uri_trailing_slash` keyword argument to `run_local_server`. If the user's redirect_uri doesn't have trailing slash (`http://localhost:{port}`), then the user can pass `redirect_uri_trailing_slash=True` when calling `run_local_server`.
