### PR TITLE
chore: prevent normalization of semver versioning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,21 @@ import io
 
 import setuptools
 
+# Disable version normalization performed by setuptools.setup()
+try:
+    # Try the approach of using sic(), added in setuptools 46.1.0
+    from setuptools import sic
+except ImportError:
+    # Try the approach of replacing packaging.version.Version
+    sic = lambda v: v
+    try:
+        # setuptools >=39.0.0 uses packaging from setuptools.extern
+        from setuptools.extern import packaging
+    except ImportError:
+        # setuptools <39.0.0 uses packaging from pkg_resources.extern
+        from pkg_resources.extern import packaging
+    packaging.version.Version = packaging.version.LegacyVersion
+
 TOOL_DEPENDENCIES = "click>=6.0.0"
 
 DEPENDENCIES = ("google-auth>=1.0.0", "requests-oauthlib>=0.7.0")
@@ -29,7 +44,7 @@ version = "0.4.4"
 
 setuptools.setup(
     name="google-auth-oauthlib",
-    version=setuptools.sic(version),
+    version=sic(version),
     author="Google Cloud Platform",
     author_email="jonwayne+google-auth@google.com",
     description="Google Authentication Library",

--- a/setup.py
+++ b/setup.py
@@ -14,9 +14,7 @@
 
 import io
 
-from setuptools import find_packages
-from setuptools import setup
-
+import setuptools
 
 TOOL_DEPENDENCIES = "click>=6.0.0"
 
@@ -29,7 +27,7 @@ with io.open("README.rst", "r") as fh:
 
 version = "0.4.4"
 
-setup(
+setuptools.setup(
     name="google-auth-oauthlib",
     version=setuptools.sic(version),
     author="Google Cloud Platform",
@@ -37,7 +35,7 @@ setup(
     description="Google Authentication Library",
     long_description=long_description,
     url="https://github.com/GoogleCloudPlatform/google-auth-library-python-oauthlib",
-    packages=find_packages(exclude=("tests*",)),
+    packages=setuptools.find_packages(exclude=("tests*",)),
     install_requires=DEPENDENCIES,
     extras_require={"tool": TOOL_DEPENDENCIES},
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ version = "0.4.4"
 
 setup(
     name="google-auth-oauthlib",
-    version=version,
+    version=setuptools.sic(version),
     author="Google Cloud Platform",
     author_email="jonwayne+google-auth@google.com",
     description="Google Authentication Library",


### PR DESCRIPTION
When there is a patch version added to semver versioning, setuptools.setup(version) will normalize the versioning from `-patch` to `.patch` which is not correct SEMVER versioning. The added feature with setuptools.sic(version) will prevent this from happening.