### PR TITLE
fix(setup.py): increase required google-auth version to >=2.13.0 (#246)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ from setuptools import setup
 
 TOOL_DEPENDENCIES = "click>=6.0.0"
 
-DEPENDENCIES = ("google-auth>=1.0.0", "requests-oauthlib>=0.7.0")
+DEPENDENCIES = ("google-auth>=2.13.0", "requests-oauthlib>=0.7.0")
 
 
 with io.open("README.rst", "r") as fh:


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
fix(setup.py): increase required google-auth version to >=2.13.0

Release-As: 0.7.0
END_COMMIT_OVERRIDE

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-auth-library-python-oauthlib/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea.
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #246 🦕
