### PR TITLE
chore: check if port is in use before returning the port to start a new server.

### DIFF
--- a/tests/unit/test_flow.py
+++ b/tests/unit/test_flow.py
@@ -251,14 +251,26 @@ class TestInstalledAppFlow(object):
             CLIENT_SECRETS_INFO, scopes=self.SCOPES
         )
 
+
+    def is_port_in_use(self, port, host='localhost'):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            return s.connect_ex((host, port)) == 0
+
     @pytest.fixture
     def port(self):
         # Creating a new server at the same port will result in
         # a 'Address already in use' error for a brief
         # period of time after the socket has been closed.
-        # Work around this in the tests by choosing a random port.
+        # Work around this in the tests by choosing a different port each time.
         # https://stackoverflow.com/questions/6380057/python-binding-socket-address-already-in-use
-        yield random.randrange(60400, 60900)
+        random_port = -1
+        for _ in range(10):
+            random_port = random.randrange(60400, 60900)
+            if not self.is_port_in_use(random_port):
+                break
+        else:
+            raise OSError("Could not find a free port")
+        yield random_port
 
     @pytest.fixture
     def socket(self, port):

--- a/tests/unit/test_flow.py
+++ b/tests/unit/test_flow.py
@@ -251,8 +251,7 @@ class TestInstalledAppFlow(object):
             CLIENT_SECRETS_INFO, scopes=self.SCOPES
         )
 
-
-    def is_port_in_use(self, port, host='localhost'):
+    def is_port_in_use(self, port, host="localhost"):
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             return s.connect_ex((host, port)) == 0
 


### PR DESCRIPTION
Currently OAuthlib has some tests that uses a port to start a local server. Sometimes both tests run using the same port as a result we get errors such as port already in use. Therefore check before returning a port