### PR TITLE
chore(python): Add support for Python 3.14

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -22,7 +22,7 @@ In order to add a feature:
   documentation.
 
 - The feature must work fully on the following CPython versions:
-  3.7, 3.8, 3.9, 3.10, 3.11, 3.12 and 3.13 on both UNIX and Windows.
+  3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13 and 3.14 on both UNIX and Windows.
 
 - The feature must not add unnecessary dependencies (where
   "unnecessary" is of course subjective, but new dependencies should
@@ -72,7 +72,7 @@ We use `nox <https://nox.readthedocs.io/en/latest/>`__ to instrument our tests.
 
 - To run a single unit test::
 
-    $ nox -s unit-3.13 -- -k <name of test>
+    $ nox -s unit-3.14 -- -k <name of test>
 
 
   .. note::
@@ -228,6 +228,7 @@ We support:
 -  `Python 3.11`_
 -  `Python 3.12`_
 -  `Python 3.13`_
+-  `Python 3.14`_
 
 .. _Python 3.7: https://docs.python.org/3.7/
 .. _Python 3.8: https://docs.python.org/3.8/
@@ -236,6 +237,7 @@ We support:
 .. _Python 3.11: https://docs.python.org/3.11/
 .. _Python 3.12: https://docs.python.org/3.12/
 .. _Python 3.13: https://docs.python.org/3.13/
+.. _Python 3.14: https://docs.python.org/3.14/
 
 
 Supported versions can be found in our ``noxfile.py`` `config`_.

--- a/noxfile.py
+++ b/noxfile.py
@@ -179,7 +179,12 @@ def install_unittest_dependencies(session, *constraints):
 def unit(session, protobuf_implementation):
     # Install all test dependencies, then install this package in-place.
 
-    if protobuf_implementation == "cpp" and session.python in ("3.11", "3.12", "3.13"):
+    if protobuf_implementation == "cpp" and session.python in (
+        "3.11",
+        "3.12",
+        "3.13",
+        "3.14",
+    ):
         session.skip("cpp implementation is not supported in python 3.11+")
 
     constraints_path = str(
@@ -387,7 +392,12 @@ def docfx(session):
 def prerelease_deps(session, protobuf_implementation):
     """Run all tests with prerelease versions of dependencies installed."""
 
-    if protobuf_implementation == "cpp" and session.python in ("3.11", "3.12", "3.13"):
+    if protobuf_implementation == "cpp" and session.python in (
+        "3.11",
+        "3.12",
+        "3.13",
+        "3.14",
+    ):
         session.skip("cpp implementation is not supported in python 3.11+")
 
     # Install all dependencies

--- a/noxfile.py
+++ b/noxfile.py
@@ -45,6 +45,7 @@ UNIT_TEST_PYTHON_VERSIONS: List[str] = [
     "3.11",
     "3.12",
     "3.13",
+    "3.14",
 ]
 UNIT_TEST_STANDARD_DEPENDENCIES = [
     "mock",

--- a/owlbot.py
+++ b/owlbot.py
@@ -43,7 +43,7 @@ s.replace(
 # Skip Cpp Unittest in 3.11, 3.12, 3.13, and 3.14
 s.replace(
     "noxfile.py",
-    '''session.python in ("3.11", "3.12", "3.13")''',
+    '''session.python in \("3.11", "3.12", "3.13"\)''',
     '''session.python in ("3.11", "3.12", "3.13", "3.14")'''
 )
 

--- a/owlbot.py
+++ b/owlbot.py
@@ -10,7 +10,7 @@ templated_files = common.py_library(
     microgenerator=True,
     cov_level=99,
     unit_test_external_dependencies=["click"],
-    unit_test_python_versions=["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"],
+    unit_test_python_versions=["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"],
     default_python_version="3.10",
 )
 s.move(templated_files, excludes=[
@@ -38,6 +38,13 @@ s.replace(
     "noxfile.py",
     '"--cov=google",',
     '"--cov=google_auth_oauthlib",',
+)
+
+# Skip Cpp Unittest in 3.11, 3.12, 3.13, and 3.14
+s.replace(
+    "noxfile.py",
+    '''session.python in ("3.11", "3.12", "3.13")''',
+    '''session.python in ("3.11", "3.12", "3.13", "3.14")'''
 )
 
 s.shell.run(["nox", "-s", "blacken"], hide_output=False)

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ setup(
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
This PR adds support for Python 3.14 to the library.

Key changes include:
 - Updates to `owlbot.py` to include Python 3.14.
 - Adding Python 3.14 to the test matrix in `.github/workflows/unittest.yml`.
 - Updating `setup.py` to include the Python 3.14 classifier.
 - Adding `testing/constraints-3.14.txt`.
 - Updating `noxfile.py` to include 3.14 sessions.
 - Updating `CONTRIBUTING.rst` to list Python 3.14 as a supported version.
