### PR TITLE
fix: add upper-bound to google-auth dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,12 @@ from setuptools import setup
 
 TOOL_DEPENDENCIES = "click>=6.0.0"
 
-DEPENDENCIES = ("google-auth>=2.15.0", "requests-oauthlib>=0.7.0")
+# TODO(https://github.com/googleapis/google-auth-library-python-oauthlib/issues/422): google-auth 2.42.0
+# introduces a change that isn't compatible with
+# google-auth-oauthlib.
+# Specifically https://github.com/googleapis/google-auth-library-python/commit/36ecb1d65883477d27faf9c2281fc289659b9903
+# which results in the unit tests to fail. Remove the upper bound once the issue is resolved.
+DEPENDENCIES = ("google-auth>=2.15.0,<2.42.0", "requests-oauthlib>=0.7.0")
 
 
 with io.open("README.rst", "r") as fh:


### PR DESCRIPTION
This PR fixes the unit tests by excluding the latest version of `google-auth` at this time (2.42.0) which includes changes that are incompatible with `google-auth-oauthlib`. 
