### PR TITLE
chore: librarian release pull request: 20260114T132622Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,7 +1,8 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:c8612d3fffb3f6a32353b2d1abd16b61e87811866f7ec9d65b59b02eb452a620
 libraries:
   - id: google-auth-oauthlib
-    version: 1.2.3
+    version: 1.2.4
+    last_generated_commit: ""
     apis: []
     source_roots:
       - .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 [1]: https://pypi.org/project/google-auth-oauthlib/#history
 
+## [1.2.4](https://github.com/googleapis/google-cloud-python/compare/google-auth-oauthlib-v1.2.3...google-auth-oauthlib-v1.2.4) (2026-01-14)
+
+
+### Bug Fixes
+
+* support google-auth >= 2.46.0 (#433) ([088a597cfa50c90d11e9a6993f2115a0eded3422](https://github.com/googleapis/google-cloud-python/commit/088a597cfa50c90d11e9a6993f2115a0eded3422))
+
 ## [1.2.3](https://github.com/googleapis/google-auth-library-python-oauthlib/compare/v1.2.2...v1.2.3) (2025-10-30)
 
 

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ with io.open("README.rst", "r") as fh:
     long_description = fh.read()
 
 
-version = "1.2.3"
+version = "1.2.4"
 
 setup(
     name="google-auth-oauthlib",


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v1.0.1
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:c8612d3fffb3f6a32353b2d1abd16b61e87811866f7ec9d65b59b02eb452a620
<details><summary>google-auth-oauthlib: 1.2.4</summary>

## [1.2.4](https://github.com/googleapis/google-auth-library-python-oauthlib/compare/v1.2.3...v1.2.4) (2026-01-14)

### Bug Fixes

* support google-auth &gt;= 2.46.0 (#433) ([088a597c](https://github.com/googleapis/google-auth-library-python-oauthlib/commit/088a597c))

</details>